### PR TITLE
use OpenJDK instead of Oracle JDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# 1.4.14
-
-* Karaf IP configurable in vhost template
 
 # 1.4.15
 
 * Switch to OpenJDK, as JAVA 7 is unable to be automatically downloaded by Java Cookbook. 
+
+# 1.4.14
+
+* Karaf IP configurable in vhost template
 
 # 1.4.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Karaf IP configurable in vhost template
 
+# 1.4.15
+
+* Switch to OpenJDK, as JAVA 7 is unable to be automatically downloaded by Java Cookbook. 
+
 # 1.4.13
 
 * Update Browsermob version to 2.1.4

--- a/attributes/common.rb
+++ b/attributes/common.rb
@@ -20,6 +20,4 @@
 #
 
 # JAVA
-default['java']['oracle']['accept_oracle_download_terms'] = 'true'
 default['java']['jdk_version'] = '7'
-default['java']['install_flavor'] = 'oracle'


### PR DESCRIPTION
Using OpenJDK 7 instead of Oracle JDK 7 as the latter is unable to be automatically downloaded by Java Cookbook.