### PR TITLE
removing homedir for karaf service user

### DIFF
--- a/recipes/karaf.rb
+++ b/recipes/karaf.rb
@@ -35,8 +35,6 @@ end
 user 'karaf user' do
   username node['aet']['karaf']['user']
   group node['aet']['karaf']['group']
-  manage_home true
-  home node['aet']['karaf']['root_dir']
   system true
   shell '/bin/bash'
   action :create


### PR DESCRIPTION
removing homedir for karaf service user as it fails for kitchen without _develop recipe

___

I hereby agree to the terms of the AET Contributor License Agreement.