### PR TITLE
Added vhost config to proxy requests to karaf port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 
+* Apache config (vhost) to proxy Web API requests to Karaf port
 * Selenium grid hub upgrade from 3.8.1 to 3.14.0
 * Dependant cookbooks upgrade and change for Mongo DB cookbook
 

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -55,6 +55,7 @@ end
   proxy
   proxy_http
   headers
+  filter
 ).each do |it|
   apache_module it do
     enable true

--- a/templates/default/etc/httpd/sites-available/aet.conf.erb
+++ b/templates/default/etc/httpd/sites-available/aet.conf.erb
@@ -9,9 +9,9 @@
     AddOutputFilterByType DEFLATE text/css
     AddOutputFilterByType DEFLATE text/javascript
 
-    <Location "/api">
+    <LocationMatch "^/((api|configs|suite|system).*)">
       Header set Access-Control-Allow-Origin "*"
-      ProxyPass http://<%= node['aet']['apache']['karaf_ip'] %>:<%= node['aet']['karaf']['web_port'] %>/api
-    </Location>
+      ProxyPassMatch http://<%= node['aet']['apache']['karaf_ip'] %>:<%= node['aet']['karaf']['web_port'] %>/$1
+    </LocationMatch>
 
 </VirtualHost>

--- a/templates/default/etc/httpd/sites-available/aet.conf.erb
+++ b/templates/default/etc/httpd/sites-available/aet.conf.erb
@@ -9,7 +9,7 @@
     AddOutputFilterByType DEFLATE text/css
     AddOutputFilterByType DEFLATE text/javascript
 
-    <LocationMatch "^/((api|configs|suite|system).*)">
+    <LocationMatch "^/((api|configs|suite|system|xunit|lock).*)">
       Header set Access-Control-Allow-Origin "*"
       ProxyPassMatch http://<%= node['aet']['apache']['karaf_ip'] %>:<%= node['aet']['karaf']['web_port'] %>/$1
     </LocationMatch>


### PR DESCRIPTION
Requests starting with:
- /api
- /configs
- /suite 
- /system 
are now being redirected to karaf port (8181 by default) to allow e.g. using domain name as a `enpointDomain` parameter when running a suite