### PR TITLE
Configurable browsermob proxy port range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # unreleased
 
+# 5.1.0
+
+* Configurable Browsermob proxy port range
+
 # 5.0.0
 
 * AET release of version 3.0.0

--- a/attributes/browsermob.rb
+++ b/attributes/browsermob.rb
@@ -30,5 +30,6 @@ default['aet']['browsermob']['user'] = 'browsermob'
 default['aet']['browsermob']['group'] = 'browsermob'
 
 default['aet']['browsermob']['port'] = '8080'
+default['aet']['browsermob']['proxy_port_range'] = '8081-8151'
 
 default['aet']['browsermob']['src_cookbook']['init_script'] = 'aet'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'karol.drazek@cognifide.com'
 license           'Apache 2.0'
 description       'Installs/Configures aet'
 long_description  'Installs/Configures aet'
-version           '5.0.0'
+version           '5.1.0'
 
 depends           'apache2', '~> 3.3.1'
 depends           'java', '~> 2.2.0'

--- a/templates/default/etc/init.d/browsermob.erb
+++ b/templates/default/etc/init.d/browsermob.erb
@@ -18,7 +18,7 @@
 . /etc/rc.d/init.d/functions
 
 DAEMON="<%= node['aet']['browsermob']['root_dir']  %>/current/bin/browsermob-proxy"
-PARAM="-port <%= node['aet']['browsermob']['port'] %>"
+PARAM="-port <%= node['aet']['browsermob']['port'] %> -proxyPortRange <%= node['aet']['browsermob']['proxy_port_range'] %>"
 LOCK_FILE="/var/lock/subsys/browsermob"
 USER="<%= node['aet']['browsermob']['user'] %>"
 


### PR DESCRIPTION
Browsermob proxy port range can now be configured by `['aet']['browsermob']['proxy_port_range']` attribute. 

According to [Browsermob docs](https://github.com/lightbody/browsermob-proxy#command-line-arguments), the default range is `(8081)-(8581)`