### PR TITLE
set proper mongo data directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased
 
+* [PR-43](https://github.com/Cognifide/aet-cookbook/pull/43) that fixes [#42](https://github.com/Cognifide/aet-cookbook/issues/42). **Important** if you're upgrading from `aet-cookbook` versions `v5.0.0` or `v5.1.0` please follow the instructions in the [PR-43 description](https://github.com/Cognifide/aet-cookbook/pull/43)
+
 # 5.1.0
 
 * Configurable Browsermob proxy port range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # unreleased
 
-* [PR-43](https://github.com/Cognifide/aet-cookbook/pull/43) that fixes [#42](https://github.com/Cognifide/aet-cookbook/issues/42). **Important** if you're upgrading from `aet-cookbook` versions `v5.0.0` or `v5.1.0` please follow the instructions in the [PR-43 description](https://github.com/Cognifide/aet-cookbook/pull/43)
+* [PR-43](https://github.com/Cognifide/aet-cookbook/pull/43) that fixes [#42](https://github.com/Cognifide/aet-cookbook/issues/42). **Important**: if you're upgrading from `aet-cookbook` versions `v5.0.0` or `v5.1.0` please follow the instructions in the [PR-43 description](https://github.com/Cognifide/aet-cookbook/pull/43)
 
 # 5.1.0
 

--- a/attributes/mongo.rb
+++ b/attributes/mongo.rb
@@ -19,5 +19,4 @@
 # limitations under the License.
 #
 default['mongodb']['package_version'] = '3.2.3'
-default['mongodb']['config']['dbpath'] =
-  '/opt/aet/mongodb/db'
+default['mongodb']['config']['mongod']['storage']['dbPath'] = '/opt/aet/mongodb/db'

--- a/test/mongo/service.rb
+++ b/test/mongo/service.rb
@@ -8,3 +8,9 @@ end
 describe port(27017) do
     it { should be_listening }
 end
+
+describe file('/opt/aet/mongodb/db') do
+  it { should exist }
+  it { should be_directory  }
+  it { should be_owned_by 'mongod' }
+end


### PR DESCRIPTION
Fixes #42
By mistake, AET MongoDB data folder was set to the default value for the `sc-mongodb` cookbook which is `/var/lib/mongo/` directory.
After this fix, MongoDB will be configured to store its data under `/opt/aet/mongodb/db`.

This is critical bugfix for the instances with separate disk/lvm configured for MognoDB.

**Important!**
If your instance is provisioned with `aet-cookbook` versions `v5.0.0` or `v5.1.0` you need to manually move your MongoDB data. Please follow steps below after upgrading your instance with version of cookbook that contains this fix:

1. Stop Karaf instance with `sudo service karaf stop`
2. Stop MongoDB instance with `sudo service mongod stop`
3. Clear `/opt/aet/mongodb/db` with `sudo rm -rf /opt/aet/mongodb/db/*`
4. Move all the data from the old director to the new with: `sudo mv -f /var/lib/mongo/* /opt/aet/mongodb/db` (depending of the size of your database it may tak a while, if you wish you may use `rsync` instead of `mv`).
5. Start MongoDB instance with `sudo service mongod start`. Check if all the databases are visible after data migration.
6. Start Karaf instance with `sudo service karaf start`